### PR TITLE
feat: add pixel art timelapse video to AsianFox shoutout

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -112,7 +112,7 @@ This fits the Neocities/gaming vibe of the site perfectly.
 **Status: CONCEPT ONLY - do not implement yet. Waiting for Ian to decide levels and which languages to include.**
 
 ## TODO / Awaiting
-- [ ] Ian to provide link to pixel art drawing stream
+- [x] Ian to provide link to pixel art drawing stream
 - [ ] More GIFs to be added
 - [ ] More pixel art assets possible
 - [ ] Domain: ianhogers.com (already owned)

--- a/src/pages/shoutouts/asianfox.astro
+++ b/src/pages/shoutouts/asianfox.astro
@@ -26,7 +26,7 @@ import Base from '../../layouts/Base.astro';
 
     <div class="prose mb-8">
       <p><strong class="text-pink-400">AsianFox</strong> was an incredible artist from another MapleStory private server. They created several art pieces - commissions that I still treasure.</p>
-      <p>I even made pixel art versions of their work and streamed the drawing process. That's how much their art meant to me.</p>
+      <p>I even made pixel art versions of their work and recorded a timelapse of the drawing process. That's how much their art meant to me.</p>
     </div>
 
     <!-- Art Gallery -->
@@ -77,7 +77,20 @@ import Base from '../../layouts/Base.astro';
         class="w-full pixel-sprite rounded"
       />
       <p class="text-xs font-mono text-gray-500 mt-2 text-center">My pixel art version of the Saint Pepsi piece</p>
-      <p class="text-xs text-gray-600 mt-1 text-center italic">I streamed the drawing process - link TBD</p>
+    </div>
+
+    <div class="pixel-box pixel-box-lavender p-3 sm:p-4 mb-8 max-w-lg mx-auto">
+      <div class="relative w-full" style="padding-bottom: 56.25%;">
+        <iframe
+          class="absolute top-0 left-0 w-full h-full rounded"
+          src="https://www.youtube-nocookie.com/embed/kptqGocceG8"
+          title="SanCoca Icon pixel art timelapse"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>
+      </div>
+      <p class="text-xs font-mono text-gray-500 mt-2 text-center">The pixel art timelapse</p>
     </div>
 
     <!-- Other art -->


### PR DESCRIPTION
Adds the pixel art timelapse video (https://youtu.be/kptqGocceG8) to the AsianFox shoutout page.

## Changes
- Embedded YouTube video (privacy-enhanced mode) below the pixel art section
- Replaced 'link TBD' placeholder with the actual video
- Updated text from 'streamed' to 'recorded a timelapse'
- Marked the DESIGN.md TODO as complete