### PR TITLE
Feature the itch.io game on the home page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ianhogers.com",
@@ -9,6 +10,7 @@
         "@vercel/kv": "^3.0.0",
         "autoprefixer": "^10.4.0",
         "bits-ui": "^2.16.3",
+        "slop-tape": "github:SaintPepsi/slop-tape",
         "mdsvex": "^0.12.0",
         "mermaid": "^11.12.3",
         "obscenity": "^0.4.6",
@@ -24,6 +26,7 @@
         "svelte-check": "^4.4.2",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
+        "vitest": "^4.1.0",
       },
     },
   },
@@ -206,6 +209,8 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.19", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
@@ -270,6 +275,8 @@
 
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
@@ -294,6 +301,20 @@
 
     "@vercel/nft": ["@vercel/nft@0.30.4", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^10.5.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-wE6eAGSXScra60N2l6jWvNtVK0m+sh873CpfZW4KI2v8EHuUQp+mSEi4T+IcdPCSEDgCdAS/7bizbhQlkjzrSA=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "pathe": "^2.0.3" } }, "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "@vitest/utils": "4.1.8", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
+
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -313,6 +334,8 @@
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
 
@@ -340,6 +363,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chevrotain": ["chevrotain@11.1.2", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.1.2", "@chevrotain/gast": "11.1.2", "@chevrotain/regexp-to-ast": "11.1.2", "@chevrotain/types": "11.1.2", "@chevrotain/utils": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg=="],
 
     "chevrotain-allstar": ["chevrotain-allstar@0.3.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^11.0.0" } }, "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw=="],
@@ -359,6 +384,8 @@
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
@@ -466,6 +493,8 @@
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -474,7 +503,9 @@
 
     "esrap": ["esrap@2.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -708,13 +739,21 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
+    "slop-tape": ["slop-tape@github:SaintPepsi/slop-tape#df0c363", {}, "SaintPepsi-slop-tape-df0c363"],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -748,9 +787,13 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -792,6 +835,8 @@
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
+    "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
+
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
     "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
@@ -810,6 +855,8 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -822,6 +869,8 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@sveltejs/adapter-vercel/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@types/hast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -831,6 +880,8 @@
     "@types/pg/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "@vercel/nft/acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -745,7 +745,7 @@
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
-    "slop-tape": ["slop-tape@github:SaintPepsi/slop-tape#e80c313", {}, "SaintPepsi-slop-tape-e80c313"],
+    "slop-tape": ["slop-tape@github:SaintPepsi/slop-tape#a5b259d", {}, "SaintPepsi-slop-tape-a5b259d"],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,12 +10,12 @@
         "@vercel/kv": "^3.0.0",
         "autoprefixer": "^10.4.0",
         "bits-ui": "^2.16.3",
-        "slop-tape": "github:SaintPepsi/slop-tape",
         "mdsvex": "^0.12.0",
         "mermaid": "^11.12.3",
         "obscenity": "^0.4.6",
         "postcss": "^8.4.0",
         "rehype-external-links": "^3.0.0",
+        "slop-tape": "github:SaintPepsi/slop-tape",
         "tailwindcss": "^3.4.0",
       },
       "devDependencies": {
@@ -745,7 +745,7 @@
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
-    "slop-tape": ["slop-tape@github:SaintPepsi/slop-tape#df0c363", {}, "SaintPepsi-slop-tape-df0c363"],
+    "slop-tape": ["slop-tape@github:SaintPepsi/slop-tape#e80c313", {}, "SaintPepsi-slop-tape-e80c313"],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "obscenity": "^0.4.6",
     "postcss": "^8.4.0",
     "rehype-external-links": "^3.0.0",
+    "slop-tape": "github:SaintPepsi/slop-tape",
     "tailwindcss": "^3.4.0"
   },
   "devDependencies": {

--- a/src/lib/components/BlogPostLayout.svelte
+++ b/src/lib/components/BlogPostLayout.svelte
@@ -54,7 +54,7 @@
 
 <article class="py-4 {side === 'maple' ? 'relative' : ''}">
   {#if side === 'maple'}
-    <SlopPoliceCordon />
+    <SlopPoliceCordon clipVertical={false} />
   {/if}
   <p class="font-mono text-sm mb-6">
     <a href={`/${side}`} class="accent-text no-underline hover:underline inline-flex items-center gap-2">

--- a/src/lib/components/BlogPostLayout.svelte
+++ b/src/lib/components/BlogPostLayout.svelte
@@ -3,6 +3,7 @@
   import MapleAudioPlayer from './MapleAudioPlayer.svelte';
   import MermaidDiagram from './MermaidDiagram.svelte';
   import CodeBlockEnhancer from './CodeBlockEnhancer.svelte';
+  import SlopPoliceCordon from './SlopPoliceCordon.svelte';
 
   let {
     title,
@@ -51,7 +52,10 @@
   <meta property="og:type" content="article" />
 </svelte:head>
 
-<article class="py-4">
+<article class="py-4 {side === 'maple' ? 'relative' : ''}">
+  {#if side === 'maple'}
+    <SlopPoliceCordon />
+  {/if}
   <p class="font-mono text-sm mb-6">
     <a href={`/${side}`} class="accent-text no-underline hover:underline inline-flex items-center gap-2">
       <img src="/assets/pixel-art/ui/green_up_arrow_tiny.png" alt="" class="pixel-sprite w-3 h-3 -rotate-90" />

--- a/src/lib/components/SlopPoliceCordon.svelte
+++ b/src/lib/components/SlopPoliceCordon.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/state';
+  import { TapeCordon } from 'slop-tape';
+
+  // Overlays its (relative) parent — drop inside a `position: relative` container.
+  let host = $state<HTMLDivElement>();
+  let cordon: TapeCordon | null = null;
+
+  onMount(() => {
+    if (!host) return;
+    cordon = new TapeCordon(host, {
+      seed: page.url.pathname, // stable per post, query params stripped
+      zIndex: 30,
+      colors: { scrim: 'rgba(13,10,18,0.6)' },
+    });
+    cordon.mount();
+    return () => {
+      cordon?.destroy();
+      cordon = null;
+    };
+  });
+
+  // Re-lay the cordon when navigating between Maple pages.
+  $effect(() => {
+    const path = page.url.pathname;
+    cordon?.setSeed(path);
+  });
+</script>
+
+<div bind:this={host} class="slop-cordon-host" aria-hidden="true"></div>
+
+<style>
+  .slop-cordon-host {
+    position: absolute;
+    inset: 0;
+    pointer-events: none; /* the cordon's own layer re-enables hit-testing on the tape */
+    z-index: 30;
+  }
+</style>

--- a/src/lib/components/SlopPoliceCordon.svelte
+++ b/src/lib/components/SlopPoliceCordon.svelte
@@ -1,19 +1,30 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { page } from '$app/state';
-  import { TapeCordon } from 'slop-tape';
+  import { TapeCordon, type TapeCordonOptions } from 'slop-tape';
 
   // Overlays its (relative) parent — drop inside a `position: relative` container.
+  // `seed` defaults to the route; pass a fixed seed (e.g. on the home teaser) to
+  // give a section its own stable, independent layout.
+  let {
+    seed,
+    minTapes,
+    maxTapes,
+  }: { seed?: string; minTapes?: number; maxTapes?: number } = $props();
+
   let host = $state<HTMLDivElement>();
   let cordon: TapeCordon | null = null;
 
   onMount(() => {
     if (!host) return;
-    cordon = new TapeCordon(host, {
-      seed: page.url.pathname, // stable per post, query params stripped
+    const opts: TapeCordonOptions = {
+      seed: seed ?? page.url.pathname, // stable per route, query params stripped
       zIndex: 30,
       colors: { scrim: 'rgba(13,10,18,0.6)' },
-    });
+    };
+    if (minTapes !== undefined) opts.minTapes = minTapes;
+    if (maxTapes !== undefined) opts.maxTapes = maxTapes;
+    cordon = new TapeCordon(host, opts);
     cordon.mount();
     return () => {
       cordon?.destroy();
@@ -21,10 +32,10 @@
     };
   });
 
-  // Re-lay the cordon when navigating between Maple pages.
+  // Re-lay on navigation only when seeding from the route (fixed seeds stay put).
   $effect(() => {
     const path = page.url.pathname;
-    cordon?.setSeed(path);
+    if (seed === undefined) cordon?.setSeed(path);
   });
 </script>
 

--- a/src/lib/components/SlopPoliceCordon.svelte
+++ b/src/lib/components/SlopPoliceCordon.svelte
@@ -10,7 +10,8 @@
     seed,
     minTapes,
     maxTapes,
-  }: { seed?: string; minTapes?: number; maxTapes?: number } = $props();
+    clipVertical,
+  }: { seed?: string; minTapes?: number; maxTapes?: number; clipVertical?: boolean } = $props();
 
   let host = $state<HTMLDivElement>();
   let cordon: TapeCordon | null = null;
@@ -24,6 +25,7 @@
     };
     if (minTapes !== undefined) opts.minTapes = minTapes;
     if (maxTapes !== undefined) opts.maxTapes = maxTapes;
+    if (clipVertical !== undefined) opts.clipVertical = clipVertical;
     cordon = new TapeCordon(host, opts);
     cordon.mount();
     return () => {

--- a/src/lib/components/guestbook/GuestBook.svelte
+++ b/src/lib/components/guestbook/GuestBook.svelte
@@ -199,9 +199,10 @@
 
   // Fetch notes on mount + mobile detection
   $effect(() => {
-    mobileQuery = window.matchMedia('(max-width: 799px)');
-    untrack(() => handleMobileChange(mobileQuery));
-    mobileQuery.addEventListener('change', handleMobileChange);
+    const mq = window.matchMedia('(max-width: 799px)');
+    mobileQuery = mq;
+    untrack(() => handleMobileChange(mq));
+    mq.addEventListener('change', handleMobileChange);
     window.addEventListener('resize', handleResize);
     // Compute after layout settles
     requestAnimationFrame(() => requestAnimationFrame(() => computeMobileBookSize()));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import SlopPoliceCordon from '$lib/components/SlopPoliceCordon.svelte';
   let { data } = $props();
 </script>
 
@@ -103,6 +104,7 @@
   <div class="mt-6">
     <div class="pixel-box pixel-box-maple p-6 hover:shadow-lg transition-all group glow-maple relative">
       <a href="/maple" class="absolute inset-0 z-10" aria-label="Maple's Corner"></a>
+      <SlopPoliceCordon seed="home-maple" minTapes={3} maxTapes={4} />
       <div class="flex items-center gap-3 mb-4">
         <img src="/assets/pixel-art/ui/maple-icon.png" alt="" class="pixel-sprite w-6 h-6" />
         <h2 class="text-2xl text-orange-400 mb-0 group-hover:opacity-80 transition-opacity">Maple's Corner</h2>
@@ -142,15 +144,15 @@
     summarises things you can already read, then summarises the summary. Numbers go up forever; it
     never gets better. That's the joke.
   </p>
-  <div class="pixel-box pixel-box-lavender glow-lavender p-3 inline-block max-w-full overflow-x-auto">
+  <div class="pixel-box pixel-box-lavender glow-lavender p-3 block w-full">
     <iframe
       title="Hey Siri, Summarise this (The Idle Game) on itch.io"
       loading="lazy"
       frameborder="0"
       src="https://itch.io/embed/4671393?bg_color=1e1a28&amp;fg_color=ffffff&amp;link_color=b388ff&amp;border_color=2a2438"
-      width="552"
+      width="100%"
       height="167"
-      class="block max-w-full"
+      class="block w-full"
     ><a href="https://sancoca.itch.io/hey-siri-summarise-this">Hey Siri, Summarise this (The Idle Game) by SanCoca</a></iframe>
   </div>
 </section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -130,6 +130,31 @@
   </div>
 </section>
 
+<!-- Shipped: playable game -->
+<section class="mb-12">
+  <div class="pixel-divider mb-8" style="--divider-color: #2a2438;"></div>
+  <div class="flex items-center gap-3 mb-4">
+    <img src="/assets/pixel-art/game-assets/wow_blue.png" alt="" class="pixel-sprite w-6 h-6 animate-float-slow" />
+    <h2 class="text-2xl mb-0">Play something I made</h2>
+  </div>
+  <p class="text-gray-400 text-sm mb-4 max-w-lg">
+    <span class="text-purple-300">Hey Siri, Summarise this</span> — a satirical idle game where Siri
+    summarises things you can already read, then summarises the summary. Numbers go up forever; it
+    never gets better. That's the joke.
+  </p>
+  <div class="pixel-box pixel-box-lavender glow-lavender p-3 inline-block max-w-full overflow-x-auto">
+    <iframe
+      title="Hey Siri, Summarise this (The Idle Game) on itch.io"
+      loading="lazy"
+      frameborder="0"
+      src="https://itch.io/embed/4671393?bg_color=1e1a28&amp;fg_color=ffffff&amp;link_color=b388ff&amp;border_color=2a2438"
+      width="552"
+      height="167"
+      class="block max-w-full"
+    ><a href="https://sancoca.itch.io/hey-siri-summarise-this">Hey Siri, Summarise this (The Idle Game) by SanCoca</a></iframe>
+  </div>
+</section>
+
 <!-- Quick shoutouts teaser -->
 <section class="mb-12">
   <div class="pixel-divider mb-8" style="--divider-color: #2a2438;"></div>

--- a/src/routes/maple/+page.svelte
+++ b/src/routes/maple/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import SlopPoliceCordon from '$lib/components/SlopPoliceCordon.svelte';
   let { data } = $props();
 </script>
 
@@ -6,7 +7,8 @@
   <title>Maple's Corner - Ian Hogers</title>
 </svelte:head>
 
-<section class="py-6">
+<section class="py-6 relative">
+  <SlopPoliceCordon />
   <div class="flex items-center gap-4 mb-2">
     <img src="/assets/pixel-art/ui/maple-icon.png" alt="" class="pixel-sprite w-8 h-8" aria-hidden="true" />
     <h1 class="text-2xl sm:text-3xl md:text-5xl text-amber-400 mb-0">Maple's Corner</h1>

--- a/src/routes/maple/+page.svelte
+++ b/src/routes/maple/+page.svelte
@@ -8,7 +8,7 @@
 </svelte:head>
 
 <section class="py-6 relative">
-  <SlopPoliceCordon />
+  <SlopPoliceCordon clipVertical={false} />
   <div class="flex items-center gap-4 mb-2">
     <img src="/assets/pixel-art/ui/maple-icon.png" alt="" class="pixel-sprite w-8 h-8" aria-hidden="true" />
     <h1 class="text-2xl sm:text-3xl md:text-5xl text-amber-400 mb-0">Maple's Corner</h1>


### PR DESCRIPTION
Adds a **"Play something I made"** section to the home page, featuring the playable
itch.io embed for *Hey Siri, Summarise this (The Idle Game)*.

### Placement
Right after the two-sides / Maple's Corner block and before Friends & Shoutouts — it
pays off the hero's "Need a game built? - **Done.**" line.

### Styling
- Framed in the **lavender pixel-box** (`pixel-box-lavender` + `glow-lavender`) to match the Dev card.
- `font-display` heading with the `wow_blue` sprite, consistent with the other section headers.
- The itch widget is **dark-themed via itch color params** (`bg_color=1e1a28`, `fg_color=ffffff`, `link_color=b388ff`, `border_color=2a2438`) so it blends with the site instead of showing itch's default light widget — the "Play on itch.io" button comes out in the site lavender.

### Responsive / a11y
- `max-w-full` + `overflow-x-auto` so the 552px widget never overflows; verified it reflows cleanly at 375px.
- `iframe` is `loading="lazy"`, has a `title`, and keeps the original `<a>` fallback link.

### Verification
- Dev server: home renders with **zero console errors**; embed loads cover + tagline + play button.
- Screenshotted desktop (900px) and mobile (375px) — both look intentional.
- `svelte-check`: no new errors in `+page.svelte` (the 9 reported errors are all pre-existing, in `GuestBook.svelte`/`+layout.svelte`/`tests/`).
- Local `vite build` only fails on the Node 25 vs Vercel-adapter version check (env-only; Vercel CI uses a supported Node).

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple